### PR TITLE
DEV - Intégration continue : Indicateur du coverage des tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,13 @@
 name: CI Dev
 
 on:
-  # CI trigger si: push sur master / pull request vers master / nouvelle release
+  # CI trigger si: push / pull request / nouvelle release
   push:
     branches:
-      master
+      '**'
   pull_request:
     branches:
-      master
+      '**'
   release:
     types:
       - created
@@ -53,8 +53,29 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
-    - name: Compilation
-      run: mvn -B package
-
     - name: Tests unitaires
-      run: mvn test
+      run: mvn -B test
+
+    - name: Génération badge Coverage
+      id: cov-badge
+      uses: cicirello/jacoco-badge-generator@v1.0.0
+      with:
+        jacoco-badge-file: coverage.svg
+
+    - name: Log taux de Coverage
+      run: |
+        echo "Coverage: ${{ steps.cov-badge.outputs.coverage }}"
+
+    - name: Publication badge Coverage
+      uses: google-github-actions/upload-cloud-storage@main
+      with:
+        credentials: ${{ secrets.GCP_CREDENTIALS }}
+        path: coverage.svg
+        destination: alternbot-coverage/badges
+
+    - name: Publication rapport Coverage
+      uses: google-github-actions/upload-cloud-storage@main
+      with:
+        credentials: ${{ secrets.GCP_CREDENTIALS }}
+        path: target/site/jacoco
+        destination: alternbot-coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,8 @@
 name: CI Dev
 
 on:
-  # CI trigger si: push / pull request / nouvelle release
+  # CI trigger si: push sur une branche / nouvelle release
   push:
-    branches:
-      '**'
-  pull_request:
     branches:
       '**'
   release:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Altern'Bot :robot:
 ===========
 
 [![Actions Status](https://github.com/B4va/alternbot-app/workflows/CI%20Dev/badge.svg?branch=za-ci)](https://github.com/B4va/alternbot-app/CI%20Dev)
+[![Coverage](https://storage.googleapis.com/alternbot-coverage/badges/coverage.svg)](https://storage.googleapis.com/alternbot-coverage/jacoco/index.html)
 
 Bot *Discord* utile aux alternants de l'Université de Lorraine.
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -120,6 +120,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>
@@ -140,4 +145,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/src/test/java/models/TestTests.java
+++ b/src/test/java/models/TestTests.java
@@ -1,0 +1,19 @@
+package models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class TestTests {
+    private models.Test instance;
+
+    @BeforeEach
+    void setUp() {
+        this.instance = new models.Test("blabla");
+    }
+
+    @Test
+    void getText() {
+        Assertions.assertEquals("blabla", this.instance.getText());
+    }
+}


### PR DESCRIPTION
### Mise en place du % de coverage des tests unitaires sur le README + rapport détaillé

- Utilisation d'un Plug-in Maven pour génération du rapport de Coverage [JaCoCo](https://www.eclemma.org/jacoco/)
- Badge + Rapport sont stockés sur un bucket Google Cloud Storage
- Montée en version du plug-in Maven [Surefire](https://maven.apache.org/surefire/maven-surefire-plugin/), la version précédente ne captait pas les tests unitaires JUnit 5