### PR TITLE
FIX - Gestion des cours supprimés

### DIFF
--- a/src/main/java/models/Session.java
+++ b/src/main/java/models/Session.java
@@ -132,4 +132,11 @@ public class Session extends Model {
   public void setSchedule(Schedule schedule) {
     this.schedule = schedule;
   }
+
+  public boolean equals(Session session) {
+    return name.equals(session.getName()) &&
+      start.equals(session.getStart()) &&
+      end.equals(session.getEnd()) &&
+      date.equals(session.getDate());
+  }
 }

--- a/src/main/java/process/data/SessionUpdateProcess.java
+++ b/src/main/java/process/data/SessionUpdateProcess.java
@@ -1,8 +1,11 @@
 package process.data;
 
+import edu.emory.mathcs.backport.java.util.Arrays;
+import edu.emory.mathcs.backport.java.util.Collections;
 import models.Session;
 import models.business.SessionChange;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,19 +16,18 @@ import java.util.stream.Collectors;
 public class SessionUpdateProcess {
 
   /**
-   * Met à jour un cours dont les données ont été récupérées.
+   * Met à jour les anciens cours enregistrés à partir d'un nouveau cours récupéré.
    *
    * @param session     cours récupéré
    * @param oldSessions ensemble des cours déjà enregistrés liés au même emploi du temps
    */
-  public List<SessionChange> update(Session session, Set<Session> oldSessions, List<SessionChange> changes) {
-    if (!isSaved(session, oldSessions)) {
+  public List<SessionChange> updateWithNew(Session session, Set<Session> oldSessions, List<SessionChange> changes) {
+    if (oldSessions.stream().noneMatch(s -> s.equals(session))) {
       session.create();
       List<Session> overlapped = oldSessions.stream()
         .filter(s -> isOverlapping(session, s))
         .collect(Collectors.toList());
-      SessionChange change = new SessionChange(session, overlapped);
-      changes.add(change);
+      changes.add(new SessionChange(session, overlapped));
       overlapped.forEach(s -> {
         s.setUpdated(true);
         s.update();
@@ -34,12 +36,28 @@ public class SessionUpdateProcess {
     return changes;
   }
 
-  private boolean isSaved(Session session, Set<Session> oldSessions) {
-    return oldSessions.stream()
-      .anyMatch(s -> session.getName().equals(s.getName()) &&
-        session.getStart().equals(s.getStart()) &&
-        session.getEnd().equals(s.getEnd()) &&
-        session.getDate().equals(s.getDate()));
+  /**
+   * Met à jour un cours à partir de l'ancien cours : détecte son éventuelle suppression.
+   *
+   * @param session     ancien cours
+   * @param newSessions ensemble des cours récupérés
+   */
+  public List<SessionChange> updateFromOld(Session session, List<Session> newSessions, List<SessionChange> changes) {
+    if (newSessions.stream().noneMatch(s -> s.equals(session)) && !isAlreadyChanged(session, changes)) {
+      List<Session> deleted = new ArrayList<>();
+      deleted.add(session);
+      deleted.forEach(s -> {
+        s.setUpdated(true);
+        s.update();
+      });
+      changes.add(new SessionChange(null, deleted));
+    }
+    return changes;
+  }
+
+  private boolean isAlreadyChanged(Session session, List<SessionChange> changes) {
+    return changes.stream()
+      .anyMatch(c -> c.getReplacedSessions().stream().anyMatch(s -> s.equals(session)));
   }
 
   private boolean isOverlapping(Session newSession, Session oldSession) {

--- a/src/main/java/process/data/SessionUpdateProcess.java
+++ b/src/main/java/process/data/SessionUpdateProcess.java
@@ -6,6 +6,7 @@ import models.Session;
 import models.business.SessionChange;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,7 +44,7 @@ public class SessionUpdateProcess {
    * @param newSessions ensemble des cours récupérés
    */
   public List<SessionChange> updateFromOld(Session session, List<Session> newSessions, List<SessionChange> changes) {
-    if (newSessions.stream().noneMatch(s -> s.equals(session)) && !isAlreadyChanged(session, changes)) {
+    if (newSessions.stream().noneMatch(s -> s.equals(session)) && !isAlreadyChanged(session, changes) && !isPast(session)) {
       List<Session> deleted = new ArrayList<>();
       deleted.add(session);
       deleted.forEach(s -> {
@@ -53,6 +54,12 @@ public class SessionUpdateProcess {
       changes.add(new SessionChange(null, deleted));
     }
     return changes;
+  }
+
+  private boolean isPast(Session session) {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.DAY_OF_MONTH, -1);
+    return session.getDate().before(calendar.getTime());
   }
 
   private boolean isAlreadyChanged(Session session, List<SessionChange> changes) {

--- a/src/main/java/process/data/SessionUpdateProcess.java
+++ b/src/main/java/process/data/SessionUpdateProcess.java
@@ -1,7 +1,5 @@
 package process.data;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-import edu.emory.mathcs.backport.java.util.Collections;
 import models.Session;
 import models.business.SessionChange;
 

--- a/src/main/java/process/publication/ScheduleChangeFormattingProcess.java
+++ b/src/main/java/process/publication/ScheduleChangeFormattingProcess.java
@@ -29,9 +29,17 @@ public class ScheduleChangeFormattingProcess {
 
   private void fillMessage(List<SessionChange> changes, StringBuilder message) {
     for (SessionChange c : changes) {
-      fillMessageWithNewSession(message, c);
-      fillMessageWithReplacedSessions(message, c);
+      if (isNewSession(c)) {
+        fillMessageWithNewSession(message, c);
+        fillMessageWithReplacedSessions(message, c);
+      } else {
+        fillMessageWithDeletedSession(message, c);
+      }
     }
+  }
+
+  private boolean isNewSession(SessionChange change) {
+    return nonNull(change.getNewSession());
   }
 
   private void fillMessageWithNewSession(StringBuilder message, SessionChange c) {
@@ -63,6 +71,19 @@ public class ScheduleChangeFormattingProcess {
           .append(timeToString(s.getEnd()))
           .append(")");
       }
+    }
+  }
+
+  private void fillMessageWithDeletedSession(StringBuilder message, SessionChange c) {
+    Session deletedSession = c.getReplacedSessions().get(0);
+    message.append("\n\nCOURS SUPPRIME :\n");
+    message
+      .append(deletedSession.getName().toUpperCase())
+      .append(" - le ").append(dateToString(deletedSession.getDate()))
+      .append(" de ").append(timeToString(deletedSession.getStart()))
+      .append(" à ").append(timeToString(deletedSession.getEnd()));
+    if (nonNull(deletedSession.getTeacher())) {
+      message.append(" (").append(deletedSession.getTeacher()).append(")");
     }
   }
 }

--- a/src/test/java/process/data/TestSessionUpdateProcess.java
+++ b/src/test/java/process/data/TestSessionUpdateProcess.java
@@ -27,6 +27,7 @@ public class TestSessionUpdateProcess {
   private static Session SESSION_RDM;
   private static Session SESSION_OL_END;
   private static Session SESSION_OL_START;
+  private static Session OLD_SESSION;
   private static final Schedule SCHEDULE = new Schedule("prom", "url");
   private static final String NAME_TEST = "CoursTest_TestSessionUpdateProcess";
   private static final String TEACHER_TEST = null;
@@ -52,6 +53,7 @@ public class TestSessionUpdateProcess {
   private static final String DATE_OL_START = "01-01-2021";
   private static final String START_OL_START = "09:00";
   private static final String END_OL_START = "11:00";
+  private static final String NAME_OLD_SESSION = "CoursTest_OldSession";
 
   @BeforeAll
   public static void init() throws ParseException {
@@ -60,6 +62,9 @@ public class TestSessionUpdateProcess {
     SESSION_TEST = new Session(NAME_TEST, TEACHER_TEST, LOCATION_TEST, stringToDate(DATE_TEST),
       stringToTime(START_TEST), stringToTime(END_TEST), SCHEDULE);
     SESSION_TEST.setId(SESSION_TEST.create());
+    OLD_SESSION = new Session(NAME_OLD_SESSION, TEACHER_TEST, LOCATION_TEST, stringToDate(DATE_TEST),
+      stringToTime(START_TEST), stringToTime(END_TEST), SCHEDULE);
+    OLD_SESSION.setId(OLD_SESSION.create());
     SESSION_RDM = new Session(NAME_RDM, TEACHER_RDM, LOCATION_RDM, stringToDate(DATE_RDM),
       stringToTime(START_RDM), stringToTime(END_RDM), SCHEDULE);
     SESSION_RDM.setId(SESSION_RDM.create());
@@ -77,6 +82,7 @@ public class TestSessionUpdateProcess {
     SESSION_RDM.delete();
     SESSION_OL_END.delete();
     SESSION_OL_START.delete();
+    OLD_SESSION.delete();
     SCHEDULE.delete();
   }
 
@@ -89,16 +95,17 @@ public class TestSessionUpdateProcess {
     sessions.stream()
       .filter(s -> s.getName().equals(NAME_TEST))
       .forEach(Model::delete);
+    OLD_SESSION.setUpdated(false);
+    OLD_SESSION.update();
   }
 
   @Test
-  public void testUpdate_new_session() {
+  public void testUpdateWithNew_new_session() {
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Collections.singleton(SESSION_RDM);
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
-    Session oldSession = Model.read(SESSION_RDM.getId(), Session.class);
     List<SessionChange> finalChanges = changes;
     assertAll(
       () -> assertEquals(updatedNbSessions, nbSessions + 1),
@@ -108,11 +115,11 @@ public class TestSessionUpdateProcess {
   }
 
   @Test
-  public void testUpdate_new_session_no_old() {
+  public void testUpdateWithNew_new_session_no_old() {
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Collections.emptySet();
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
     List<SessionChange> finalChanges = changes;
     assertAll(
@@ -123,11 +130,11 @@ public class TestSessionUpdateProcess {
   }
 
   @Test
-  public void testUpdate_overlapping_session_with_end() {
+  public void testUpdateWithNew_overlapping_session_with_end() {
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Collections.singleton(SESSION_OL_END);
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
     Session oldSession = Model.read(SESSION_OL_END.getId(), Session.class);
     List<SessionChange> finalChanges = changes;
@@ -142,11 +149,11 @@ public class TestSessionUpdateProcess {
   }
 
   @Test
-  public void testUpdate_overlapping_session_with_start() {
+  public void testUpdateWithNew_overlapping_session_with_start() {
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Collections.singleton(SESSION_OL_START);
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
     Session oldSession = Model.read(SESSION_OL_START.getId(), Session.class);
     List<SessionChange> finalChanges = changes;
@@ -161,11 +168,11 @@ public class TestSessionUpdateProcess {
   }
 
   @Test
-  public void testUpdate_multiple_overlapping() {
+  public void testUpdateWithNew_multiple_overlapping() {
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Sets.newSet(SESSION_OL_END, SESSION_OL_START);
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
     Session oldSession1 = Model.read(SESSION_OL_END.getId(), Session.class);
     Session oldSession2 = Model.read(SESSION_OL_START.getId(), Session.class);
@@ -183,14 +190,14 @@ public class TestSessionUpdateProcess {
   }
 
   @Test
-  public void testUpdate_already_saved() throws ParseException {
+  public void testUpdateWithNew_already_saved() throws ParseException {
     Session alreadySaved = new Session(NAME_TEST, TEACHER_TEST, LOCATION_TEST, stringToDate(DATE_TEST),
       stringToTime(START_TEST), stringToTime(END_TEST), SCHEDULE);
     alreadySaved.setId(alreadySaved.create());
     int nbSessions = Model.readAll(Session.class).size();
     List<SessionChange> changes = new ArrayList<>();
     Set<Session> oldSessions = Collections.singleton(alreadySaved);
-    changes = PROCESS.update(SESSION_TEST, oldSessions, changes);
+    changes = PROCESS.updateWithNew(SESSION_TEST, oldSessions, changes);
     int updatedNbSessions = Model.readAll(Session.class).size();
     List<SessionChange> finalChanges = changes;
     assertAll(
@@ -198,5 +205,36 @@ public class TestSessionUpdateProcess {
       () -> assertFalse(alreadySaved.isUpdated()),
       () -> assertTrue(finalChanges.isEmpty())
     );
+  }
+
+  @Test
+  public void testUpdateFromOld_deleted() {
+    List<SessionChange> changes = new ArrayList<>();
+    PROCESS.updateFromOld(OLD_SESSION, Collections.emptyList(), changes);
+    assertAll(
+      () -> assertTrue(OLD_SESSION.isUpdated()),
+      () -> assertFalse(changes.isEmpty())
+    );
+  }
+
+  @Test
+  public void testUpdateFromOld_not_changed() throws ParseException {
+    List<SessionChange> changes = new ArrayList<>();
+    Session newSession = new Session(NAME_OLD_SESSION, TEACHER_TEST, LOCATION_TEST, stringToDate(DATE_TEST),
+      stringToTime(START_TEST), stringToTime(END_TEST), SCHEDULE);
+    List<Session> newSessions = Collections.singletonList(newSession);
+    PROCESS.updateFromOld(OLD_SESSION, newSessions, changes);
+    assertTrue(changes.isEmpty());
+  }
+
+  @Test
+  public void testUpdateFromOld_already_in_session_changes() throws ParseException {
+    List<SessionChange> changes = new ArrayList<>();
+    Session alreadyChanged = new Session(NAME_OLD_SESSION, TEACHER_TEST, LOCATION_TEST, stringToDate(DATE_TEST),
+      stringToTime(START_TEST), stringToTime(END_TEST), SCHEDULE);
+    changes.add(new SessionChange(new Session(), Collections.singletonList(alreadyChanged)));
+    List<Session> newSessions = Collections.emptyList();
+    PROCESS.updateFromOld(OLD_SESSION, newSessions, changes);
+    assertEquals(changes.size(), 1);
   }
 }

--- a/src/test/java/process/publication/TestScheduleChangeFormattingProcess.java
+++ b/src/test/java/process/publication/TestScheduleChangeFormattingProcess.java
@@ -59,6 +59,11 @@ public class TestScheduleChangeFormattingProcess {
       + "\n\nNOUVEAU COURS :"
       + "\nINFORMATIQUE - le 01-01-2020 de 14:00 à 15:00 (M. Prof)"
       + "\n```";
+  private static final String MESSAGE_DELETED_SESSION =
+    "@everyone \nChangement d'emploi du temps :information_source:\n```"
+      + "\n\nCOURS SUPPRIME :"
+      + "\nINFORMATIQUE - le 01-01-2020 de 14:00 à 15:00 (M. Prof)"
+      + "\n```";
   private static Session SESSION;
   private static final String SESSION_NAME = "Informatique";
   private static final String SESSION_DATE = "01-01-2020";
@@ -68,14 +73,9 @@ public class TestScheduleChangeFormattingProcess {
   private static final String SESSION_LOCATION = "A01";
 
   @BeforeAll
-  public static void init() {
-    try {
+  public static void init() throws ParseException {
       SESSION = new Session(SESSION_NAME, SESSION_TEACHER, SESSION_LOCATION,
         stringToDate(SESSION_DATE), stringToTime(SESSION_START), stringToTime(SESSION_END), null);
-    } catch (ParseException e) {
-      e.printStackTrace();
-      fail();
-    }
   }
 
   @Test
@@ -109,32 +109,27 @@ public class TestScheduleChangeFormattingProcess {
   }
 
   @Test
-  public void testFormat_no_teacher() {
-    Session session = null;
-    try {
-      session = new Session(SESSION_NAME, null, SESSION_LOCATION, stringToDate(SESSION_DATE),
+  public void testFormat_no_teacher() throws ParseException {
+    Session session = new Session(SESSION_NAME, null, SESSION_LOCATION, stringToDate(SESSION_DATE),
         stringToTime(SESSION_START), stringToTime(SESSION_END), null);
-    } catch (ParseException e) {
-      e.printStackTrace();
-      fail();
-    }
     List<SessionChange> changes = singletonList(new SessionChange(session, Collections.emptyList()));
     String test = PROCESS.format(changes);
     assertEquals(MESSAGE_SESSION_NO_TEACHER, test);
   }
 
   @Test
-  public void testFormat_no_location() {
-    Session session = null;
-    try {
-      session = new Session(SESSION_NAME, SESSION_TEACHER, null, stringToDate(SESSION_DATE),
+  public void testFormat_no_location() throws ParseException {
+    Session session = new Session(SESSION_NAME, SESSION_TEACHER, null, stringToDate(SESSION_DATE),
         stringToTime(SESSION_START), stringToTime(SESSION_END), null);
-    } catch (ParseException e) {
-      e.printStackTrace();
-      fail();
-    }
     List<SessionChange> changes = singletonList(new SessionChange(session, Collections.emptyList()));
     String test = PROCESS.format(changes);
     assertEquals(MESSAGE_SESSION_NO_LOCATION, test);
+  }
+
+  @Test
+  public void testFormat_deleted_session() {
+    List<SessionChange> changes = singletonList(new SessionChange(null, Collections.singletonList(SESSION)));
+    String test = PROCESS.format(changes);
+    assertEquals(MESSAGE_DELETED_SESSION, test);
   }
 }


### PR DESCRIPTION
J'ai vérifié le bon fonctionnement avec les tests unitaire, mais je prendrai également le temps de trouver une façon de tester ça "en réel" pour éviter de tout casser.
Solution de test : Ajouter un cours fictif en base de données via une requête SQL, puis lancer l'application. Ce cours ne sera pas retrouvé dans les données récupérées auprès de l'IUT et sera donc considéré comme supprimé.
Si tout va bien, il devra donc être supprimé de la base et un message alertant de sa suppression doit être envoyé sur le serveur discord.