### PR TITLE
[FIX] Correction de la suppression des Session en cours de déroulement

### DIFF
--- a/src/main/java/models/Session.java
+++ b/src/main/java/models/Session.java
@@ -5,6 +5,7 @@ import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
+import java.util.Calendar;
 import java.util.Date;
 
 @Entity
@@ -138,5 +139,11 @@ public class Session extends Model {
       start.equals(session.getStart()) &&
       end.equals(session.getEnd()) &&
       date.equals(session.getDate());
+  }
+
+  public boolean isPast() {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.DAY_OF_MONTH, -1);
+    return date.before(calendar.getTime());
   }
 }

--- a/src/main/java/models/Session.java
+++ b/src/main/java/models/Session.java
@@ -141,6 +141,10 @@ public class Session extends Model {
       date.equals(session.getDate());
   }
 
+  /**
+   * Indique si le cours est considéré comme passé.
+   * @return true si la date du cours précède le jour actuel (sans prise en compte de l'horaire
+   */
   public boolean isPast() {
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.DAY_OF_MONTH, -1);

--- a/src/main/java/process/data/SessionUpdateProcess.java
+++ b/src/main/java/process/data/SessionUpdateProcess.java
@@ -4,7 +4,6 @@ import models.Session;
 import models.business.SessionChange;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,7 +41,7 @@ public class SessionUpdateProcess {
    * @param newSessions ensemble des cours récupérés
    */
   public List<SessionChange> updateFromOld(Session session, List<Session> newSessions, List<SessionChange> changes) {
-    if (newSessions.stream().noneMatch(s -> s.equals(session)) && !isAlreadyChanged(session, changes) && !isPast(session)) {
+    if (newSessions.stream().noneMatch(s -> s.equals(session)) && !isAlreadyChanged(session, changes) && !session.isPast()) {
       List<Session> deleted = new ArrayList<>();
       deleted.add(session);
       deleted.forEach(s -> {
@@ -52,12 +51,6 @@ public class SessionUpdateProcess {
       changes.add(new SessionChange(null, deleted));
     }
     return changes;
-  }
-
-  private boolean isPast(Session session) {
-    Calendar calendar = Calendar.getInstance();
-    calendar.add(Calendar.DAY_OF_MONTH, -1);
-    return session.getDate().before(calendar.getTime());
   }
 
   private boolean isAlreadyChanged(Session session, List<SessionChange> changes) {


### PR DESCRIPTION
**Problème** : La récupération des données IUT permet de récupérer tous les cours futurs (non passés). La détection des cours supprimés vérifie que les cours futurs (non passés) enregistrés en base existent toujours. Or la notion de cours passé n'était pas la même pour les deux process. 

J'ai donc généralisé la notion en ajoutant la méthode au modèle directement : Les cours passés correspondent à tous les cours dont la date précède la date du jour, sans prise en compte de l'horaire.

Exemple : Le 02-02-2021 à 10h00
- Un cours du 01-02-2021 est considéré comme passé
- Un cours du 02-02-2021 commençant à 8h00 n'est pas considéré comme passé